### PR TITLE
fix: return results when there is no anti strand transcripts

### DIFF
--- a/R/processFEQ_WES.R
+++ b/R/processFEQ_WES.R
@@ -10,8 +10,10 @@ processFEQ <-function(inPath,anntxdb,readStrands="UN",chromRef=as.character(c(1:
   
   #process Anti strand transcripts 
   asIDs = which(grepl("-AS1", feqRaw$Transcript) == TRUE)
-  asTranscripts = feqRaw[asIDs, ]
-  feqRaw = feqRaw[-asIDs, ]
+  if (length(asIDs) > 0) {
+    asTranscripts = feqRaw[asIDs, ]
+    feqRaw = feqRaw[-asIDs, ]
+  }
   
   #generate feq
   res=feqRaw[,c(2,4)]


### PR DESCRIPTION
When there is no anti strand transcripts found the feqRaw will be empty and no mate-pair results are generated!